### PR TITLE
bugfix for changes to currentItem object

### DIFF
--- a/wk_anki_mode.js
+++ b/wk_anki_mode.js
@@ -584,31 +584,22 @@ window.ankimode = {};
             var currentItem = getCurrentItem();
             var questionType = getQuestionType();
             if (questionType === "meaning") {
-                var answer = currentItem.meanings.join(", ");
+                var answer = currentItem.meanings.map(m => m.text).join(", ");
                 let synonyms = quiz_input.quizUserSynonymsOutlet.synonymsForSubjectId(getCurrentItem().id);
                 if (synonyms && synonyms.length) {
                     answer += " (" + synonyms.join(", ") + ")";
                 }
 
-                firstCorrectAnswer = currentItem.meanings[0];
+                firstCorrectAnswer = currentItem.meanings[0].text;
                 $("#user-response,#WKANKIMODE_answer_input").val(answer);
             } else { //READING QUESTION
                 var i = 0;
                 var singleAnswer = "";
                 var fullAnswer = "";
-                if (currentItem.type == "Vocabulary") {
-                    singleAnswer += currentItem.readings[0].reading;
-                    fullAnswer = currentItem.readings.map(x => x.reading).join(", ");
-                } else if (currentItem.primary_reading_type == 'kunyomi') {
-                    singleAnswer += currentItem.kunyomi[0];
-                    fullAnswer = currentItem.kunyomi.join(", ");
-                } else if (currentItem.primary_reading_type == 'nanori') {
-                    singleAnswer += currentItem.nanori[0];
-                    fullAnswer = currentItem.nanori.join(", ");
-                } else {
-                    singleAnswer += currentItem.onyomi[0];
-                    fullAnswer = currentItem.onyomi.join(", ");
-                }
+
+                singleAnswer += currentItem.readings[0].text;
+                fullAnswer = currentItem.readings.map(x => x.text).join(", ");
+
                 firstCorrectAnswer = singleAnswer;
                 $("#user-response").val(singleAnswer);
 


### PR DESCRIPTION
### Overview
* After a recent Wanikani update, the currentItem object is formatted differently, which was causing errors in the script.

### Whats in the PR
* bugfix for changes to currentItem object


### Testing
* updated tampermonkey script locally and confirmed that I am able to answer and mark answers as incorrect.


### Notes
* with the new updates to the currentItem.meanings, I am not 100% sure if more meanings are being returned than before, i.e. each meaning has a "kind" property, which is either "primary", "alternative" , "allowed". For now I am returning them all.

