### PR TITLE
Only primary and alternative meanings shown

### DIFF
--- a/wk_anki_mode.js
+++ b/wk_anki_mode.js
@@ -584,7 +584,10 @@ window.ankimode = {};
             var currentItem = getCurrentItem();
             var questionType = getQuestionType();
             if (questionType === "meaning") {
-                var answer = currentItem.meanings.map(m => m.text).join(", ");
+                var answer = currentItem.meanings
+                   .filter(m => m.kind === 'primary' || m.kind === 'alternative')
+                   .map(m => m.text)
+                   .join(", ");
                 let synonyms = quiz_input.quizUserSynonymsOutlet.synonymsForSubjectId(getCurrentItem().id);
                 if (synonyms && synonyms.length) {
                     answer += " (" + synonyms.join(", ") + ")";


### PR DESCRIPTION
Very small change to avoid showing an extreme amount of options for vocab, or readings WK simply won't accept for kanji reviews. This is equivalent to what it used to show prior to WK changing the structure of the objects on their end.